### PR TITLE
Fix force-unwrap Nil optional error

### DIFF
--- a/BLE Test/Extensions.swift
+++ b/BLE Test/Extensions.swift
@@ -162,10 +162,10 @@ func printLog(obj:AnyObject, funcName:String, logString:String?) {
     }
     
     if logString != nil {
-        print("\(obj.classForCoder!.description()) \(funcName) : \(logString!)")
+        print("\(obj) \(funcName) : \(logString!)")
     }
     else {
-        print("\(obj.classForCoder!.description()) \(funcName)")
+        print("\(obj) \(funcName)")
     }
     
 }


### PR DESCRIPTION
The `obj` parameter doesn't necessarily have a `classForCoder`. Just letting the variable get interpolated in to the string via the default method seemed to work fine.
